### PR TITLE
Fixes for overflowing edit text width and refilling args when hitting a breakpoint

### DIFF
--- a/src/main/kotlin/com/jetbrains/rider/ezargs/actions/ArgumentsInputField.kt
+++ b/src/main/kotlin/com/jetbrains/rider/ezargs/actions/ArgumentsInputField.kt
@@ -75,12 +75,12 @@ class ArgumentsInputField : AnAction(), DumbAware, CustomComponentAction {
                 ) {
                     override fun getPreferredSize(): Dimension {
                         val height = JBUI.scale(ActionToolbar.DEFAULT_MINIMUM_BUTTON_SIZE.height + 5)
-                        val prefSize = Dimension(super.getPreferredSize().width, height)
+                        val prefSize = Dimension(700, height)
                         val insets = border.getBorderInsets(this)
                         val editorField = EditorComboBox::class.java.getDeclaredField("myEditorField")
                         editorField.isAccessible = true
                         val editorTextField = editorField.get(this) as EditorTextField
-                        editorTextField.component.preferredSize = Dimension(editorTextField.component.preferredSize.width,
+                        editorTextField.component.preferredSize = Dimension(700,
                             height - insets.top - insets.bottom - borderWidth * 2)
                         return prefSize
                     }

--- a/src/main/kotlin/com/jetbrains/rider/ezargs/services/EzArgsService.kt
+++ b/src/main/kotlin/com/jetbrains/rider/ezargs/services/EzArgsService.kt
@@ -42,7 +42,6 @@ class EzArgsService(private val project: Project) : DocumentListener {
         application.assertIsDispatchThread()
         val trimmedArgs = newArguments.trim()
         PropertiesComponent.getInstance(project).setValue(LAST_USED_ARGUMENT_PROPERTY, trimmedArgs)
-        if (trimmedArgs.isEmpty()) return
 
         history.remove(trimmedArgs)
         history.addFirst(trimmedArgs)


### PR DESCRIPTION
Hello,

I've made some changes to fix the following issues:

1. The edit text can overflow off the side of the screen after inputting a very long list of argument. To fix this I changed the width to a hard-coded size of 700. This gives you plenty of space to work with for most argument lists and prevents the issue of your whole toolbar getting pushed off the screen from a long argument list. Ideally this would be a setting the user can change, but I don't know enough about Rider plugin dev to be able to add one. I hope this will still be accepted anyways :)
2. If you clear the arguments and then hit a breakpoint it will refill with the last arguments you used, which results in unexpected arguments getting applied the next time you run the application. To fix this, I made it allow saving a history item that is an empty string, that way it will reselect the empty entry instead of something else.