### PR TITLE
Add blank option to top of combo box

### DIFF
--- a/src/main/kotlin/com/jetbrains/rider/ezargs/ui/CmdlineComboBoxComponent.kt
+++ b/src/main/kotlin/com/jetbrains/rider/ezargs/ui/CmdlineComboBoxComponent.kt
@@ -151,7 +151,10 @@ class CmdlineComboBoxComponent(private val project: Project) : ComboBox<String>(
     }
 
     fun setHistory(history: Array<String>) {
-        model = DefaultComboBoxModel(history)
+        val newModel = DefaultComboBoxModel(history)
+        newModel.insertElementAt("", 0) // Add blank option to top of combo box
+
+        model = newModel
     }
 
     fun setText(text: String) {


### PR DESCRIPTION
This adds a blank option at the top of the dropdown when clicking on the command box. Making it easier to launch with no arguments. Previously, I would need to select all the arguments in the box and delete them manually.